### PR TITLE
Add localizations and validation step

### DIFF
--- a/.github/workflows/validate_code.yml
+++ b/.github/workflows/validate_code.yml
@@ -1,0 +1,40 @@
+name: Validate Code
+
+on:
+  pull_request:
+    types: [synchronize, opened, reopened, edited]
+
+jobs:
+  main:
+    name: Review, Lint, Verify
+    runs-on: macOS-latest
+    steps:
+      - name: git checkout
+        uses: actions/checkout@v3
+
+      - name: ruby versions
+        run: |
+          ruby --version
+          gem --version
+          bundler --version
+
+      - name: ruby setup
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.3
+          bundler-cache: true
+
+      # additional steps here, if needed
+
+      - name: danger
+        env:
+          DANGER_GITHUB_API_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}
+        run: bundle exec danger --verbose --fail-on-errors=true
+
+      - name: Clone SwiftPolyglot
+        run: git clone https://github.com/appdecostudio/SwiftPolyglot.git --branch=1.1.0 ../SwiftPolyglot
+
+      - name: validate translations
+        run: |
+          swift build --package-path ../SwiftPolyglot --configuration release
+          swift run --package-path ../SwiftPolyglot swiftpolyglot en --error-on-missing

--- a/Code Relay/Code Relay/Localizable.xcstrings
+++ b/Code Relay/Code Relay/Localizable.xcstrings
@@ -2,19 +2,55 @@
   "sourceLanguage" : "en",
   "strings" : {
     "Developed at " : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Developed at "
+          }
+        }
+      }
     },
     "Guide to Leeds" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Guide to Leeds"
+          }
+        }
+      }
     },
     "Home" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Home"
+          }
+        }
+      }
     },
     "Settings" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Settings"
+          }
+        }
+      }
     },
     "SwiftLeeds" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SwiftLeeds"
+          }
+        }
+      },
+      "shouldTranslate" : false
     }
   },
   "version" : "1.0"


### PR DESCRIPTION
- Adds `SwiftPolyglot` PR step that validates that all localizations are present in the String Catalog (only using `en` for now)
- Adds `en` localizations for existing String Catalog entries

This isn't a blocking step for PRs :)